### PR TITLE
fix: 같은 이미지 URL이 보일 때 imgUrl 중 빈문자열이면 sample image가 안보이는 현상 해결

### DIFF
--- a/src/components/modal/FilmRecipeModal.tsx
+++ b/src/components/modal/FilmRecipeModal.tsx
@@ -41,7 +41,13 @@ const FilmRecipeModal = ({
 	return (
 		<ModalLayout id={id} isOpen={isOpen} type={type} title={title} onClose={onClose}>
 			<Group>
-				<LazyImage src={imgSrc ?? '/sample.jpg'} alt="recipe sample image" width={'100%'} height={'100%'} lazy={true} />
+				<LazyImage
+					src={imgSrc.includes(import.meta.env.VITE_SUPABASE_FILMRECIPE_URL) ? imgSrc : '/sample.jpg'}
+					alt="recipe sample image"
+					width={'100%'}
+					height={'100%'}
+					lazy={true}
+				/>
 
 				<InfoList>
 					<li>


### PR DESCRIPTION
- `FilmRecipeModal` 컴포넌트 내 `LazyImage` 에서 같은 이미지 URL이 보일 때 imgUrl 중 빈문자열이면 sample image가 안보이는 현상 해결